### PR TITLE
Hide survey data sent after the project end date

### DIFF
--- a/generate_outputs.py
+++ b/generate_outputs.py
@@ -140,7 +140,7 @@ if __name__ == "__main__":
     data = ProductionFile.generate(data, production_csv_output_path)
 
     log.info("Auto Coding Surveys...")
-    data = AutoCodeSurveys.auto_code_surveys(user, data, coded_dir_path)
+    data = AutoCodeSurveys.auto_code_surveys(user, data, pipeline_configuration, coded_dir_path)
 
     log.info("Applying Manual Codes from Coda...")
     data = ApplyManualCodes.apply_manual_codes(user, data, prev_coded_dir_path)

--- a/src/auto_code_surveys.py
+++ b/src/auto_code_surveys.py
@@ -3,25 +3,40 @@ from os import path
 
 from core_data_modules.cleaners import Codes
 from core_data_modules.cleaners.cleaning_utils import CleaningUtils
+from core_data_modules.logging import Logger
 from core_data_modules.traced_data import Metadata
 from core_data_modules.traced_data.io import TracedDataCodaV2IO
 from core_data_modules.util import IOUtils
+from dateutil.parser import isoparse
 
 from src.lib.code_schemes import CodeSchemes
 from src.lib.pipeline_configuration import PipelineConfiguration
+
+log = Logger(__name__)
 
 
 class AutoCodeSurveys(object):
     SENT_ON_KEY = "sent_on"
 
     @classmethod
-    def auto_code_surveys(cls, user, data, coda_output_dir):
+    def auto_code_surveys(cls, user, data, pipeline_configuration, coda_output_dir):
         # Auto-code surveys
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
                 if cc.cleaner is not None:
                     CleaningUtils.apply_cleaner_to_traced_data_iterable(user, data, plan.raw_field, cc.coded_field,
                                                                         cc.cleaner, cc.code_scheme)
+
+        # Remove survey data sent after the project finished
+        log.info("Removing survey messages sent after the end of the project")
+        out_of_range_count = 0
+        for td in data:
+            for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
+                if plan.time_field in td and isoparse(td[plan.time_field]) > pipeline_configuration.project_end_date:
+                    out_of_range_count += 1
+                    td.hide_keys({plan.raw_field, plan.time_field},
+                                 Metadata(user, Metadata.get_call_location(), time.time()))
+        log.info(f"Removed {out_of_range_count} survey messages sent after the end of the project")
 
         # For any locations where the cleaners assigned a code to a sub district, set the district code to NC
         # (this is because only one column should have a value set in Coda)
@@ -37,7 +52,7 @@ class AutoCodeSurveys(object):
                     td.append_data({"district_coded": nc_label.to_dict()},
                                    Metadata(user, Metadata.get_call_location(), time.time()))
 
-        # Output single-scheme answers to coda for manual verification + coding
+        # Output survey responses to coda for manual verification + coding
         IOUtils.ensure_dirs_exist(coda_output_dir)
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             TracedDataCodaV2IO.compute_message_ids(user, data, plan.raw_field, plan.id_field)


### PR DESCRIPTION
Normally we set the end date in Rapid Pro, but that doesn't work for us here since Baidoa is running a week behind. 

It's also a bit weird to be setting the RQA end date in the pipeline but relying on Rapid Pro for the surveys end date, so perhaps we should always be doing this in future.